### PR TITLE
Add initial upgrades doc (upgrade path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ Link to [proposal](https://github.com/opencontainers/tob/blob/main/proposals/wg-
 * WG Meeting: [Tuesdays at 11:00am PT (Pacific Time)](https://zoom.us/j/92128676364) (weekly). [Convert to your timezone](https://dateful.com/convert/pt-pacific-time?t=11am).
   * [Meeting notes and Agenda](https://docs.google.com/document/d/1SVOWQTowigXzbYdorzfa7tMmrcm91yK12LvSONqziJY/edit).
 
+## In Progress
+
+The following documents are actively being updated by the WG:
+
+| Document                         | Description                                                         |
+| ---------------------------------| ------------------------------------------------------------------- |
+| [Upgrading](./docs/UPGRADING.md) | A description of upgrade scenarios at various stages of adoption    |
+
 ## Organizers
 
 * Lachlan Evenson (@lachie83)

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,0 +1,38 @@
+# Upgrading
+
+This document is a place to outline the upgrade path for
+both clients and vendors, considering that not all will adopt
+the processes designed by this WG at once (or perhaps ever).
+
+## Extensions API for Distribution
+
+Beginning in OCI Distribution Spec v1.1.0 (not yet released), the
+[Extensions API for Distribution](https://github.com/opencontainers/distribution-spec/tree/main/extensions)
+will provide a method for asking a registry (or individual repository) for which extensions are supported:
+
+```HTTP
+GET /v2/_oci/ext/discover
+```
+
+```HTTP
+GET /v2/{name}/_oci/ext/discover
+```
+
+```HTTP
+200 OK
+Content-Length: <length>
+Content-Type: application/json
+
+{
+    "extensions": [
+        {
+            "name": "_<extension>",
+            "description": "",
+            "url": "..."
+        }
+    ]
+}
+```
+
+This may provide a useful upgrade path as new APIs designed by this WG are
+proposed but not yet accepted by other parts of the OCI and wider community.


### PR DESCRIPTION
Add another doc that is a placeholder for documenting the upgrade path.

Specifically called out the Extensions API (merged to distribution-spec yesterday) as a useful tool available to us for this purpose.

Builds atop of https://github.com/opencontainers/wg-reference-types/pull/5

cc @nishakm @sudo-bmitch