### PR TITLE
Fix links to proposals in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ The following proposals are currently being evaluated by the WG:
 
 | ID | Link                              | Description            |
 | -- | --------------------------------- | ---------------------- |
-| A  | [View](./proposals/PROPOSAL_A.md) | *Reserved for Steve*   |
-| B  | [View](./proposals/PROPOSAL_B.md) | *Reserved for Dan*     |
-| C  | [View](./proposals/PROPOSAL_C.md) | *Reserved for Nisha*   |
-| D  | [View](./proposals/PROPOSAL_D.md) | No Changes             |
+| A  | [View](./docs/proposals/PROPOSAL_A.md) | *Reserved for Steve*   |
+| B  | [View](./docs/proposals/PROPOSAL_B.md) | *Reserved for Dan*     |
+| C  | [View](./docs/proposals/PROPOSAL_C.md) | *Reserved for Nisha*   |
+| D  | [View](./docs/proposals/PROPOSAL_D.md) | No Changes             |
 
 *Want to add a new proposal? Submit a PR following the format of the
 [template](./docs/TEMPLATE.md).*


### PR DESCRIPTION
In #14, the links were to `./proposals/`, but in #13, they are to `./docs/proposals/`. Going with the latter.