### PR TITLE
Add Inactive Proposals section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,24 @@ Link to [governance](./GOVERNANCE.md) document.
 
 ### Proposals
 
-The following proposals are currently being evaluated by the WG:
+The following proposal ("E") is actively under revision and represents the
+current direction of the WG:
 
-| ID | Link                                   | Description                               |
-| -- | -------------------------------------- | ----------------------------------------- |
+| ID | Link                                   | Description  |
+| -- | -------------------------------------- | ------------ |
+| E  | [View](./docs/proposals/PROPOSAL_E.md) | Cherry pick  |
+
+### Inactive Proposals
+
+After much discussion, the following proposals are no longer being evaluated by the WG:
+
+| ID | Link                                   | Description                                                               |
+| -- | -------------------------------------- | ------------------------------------------------------------------------- |
 | A  | [View](./docs/proposals/PROPOSAL_A.md) | Defines a new artifact manifest and corresponding referrers extension API |
-| B  | [View](./docs/proposals/PROPOSAL_B.md) | Add "reference" field to existing schemas |
-| C  | [View](./docs/proposals/PROPOSAL_C.md) | Create Node manifest                      |
-| D  | [View](./docs/proposals/PROPOSAL_D.md) | No Changes                                |
-| E  | [View](./docs/proposals/PROPOSAL_E.md) | Cherry pick                               |
-| F  | [View](./docs/proposals/PROPOSAL_F.md) | OCI Index references it all               |
-
-*Want to add a new proposal? Submit a PR following the format of the
-[template](./docs/TEMPLATE.md).*
+| B  | [View](./docs/proposals/PROPOSAL_B.md) | Add "reference" field to existing schemas                                 |
+| C  | [View](./docs/proposals/PROPOSAL_C.md) | Create Node manifest                                                      |
+| D  | [View](./docs/proposals/PROPOSAL_D.md) | No Changes                                                                |
+| F  | [View](./docs/proposals/PROPOSAL_F.md) | OCI Index references it all                                               |
 
 ### Documents
 


### PR DESCRIPTION
Based on discussion on call today and in #56, denote which proposals are no longer being evaluated, and point to Proposal E as the current direction of the WG. Resolves #56