### PR TITLE
Explain how to create the hash

### DIFF
--- a/docs/proposals/PROPOSAL_E.md
+++ b/docs/proposals/PROPOSAL_E.md
@@ -177,7 +177,7 @@ For registries that do not support the `referrers` API, a tag MUST be pushed for
 - E.g. `registry.example.org/project:sha256-0000000000000000000000000000000000000000000000000000000000000000.0404040404040404.sbom`
 - `<alg>`: the digest algorithm
 - `<ref>`: the digest from the `refers` field (limit of 64 characters)
-- `<hash>`: the digest of this artifact (limit of 16 characters)
+- `<hash>`: the digest of this artifact (first 16 characters)
 - `<type>`: type of artifact for filtering (limit of 5 characters)
 - Querying for referrers requires the client to get the tag listing, and filter for matching `<alg>`, `<ref>`, and `<type>` entries.
 - Adding a `<hash>` of the artifact allows multiple artifacts of the same type to exist with little risk of collision or race conditions.


### PR DESCRIPTION
Without this, different clients may use different tags for the same
referrers.

Signed-off-by: James Hewitt <james.hewitt@uk.ibm.com>