### PR TITLE
Remove schemaVersion from new artifact manifest

### DIFF
--- a/docs/proposals/PROPOSAL_E.md
+++ b/docs/proposals/PROPOSAL_E.md
@@ -57,7 +57,6 @@ Create a new artifact media type to support future use cases where a separate co
 
 ```jsonc
 {
-  "schemaVersion": 2,
   "mediaType": "application/vnd.oci.artifact.manifest.v1+json",
   "blobs": [
     // optional list, ordering is not enforced by the spec


### PR DESCRIPTION
Signed-off-by: Sajay Antony <sajaya@microsoft.com>

This change is to remove the `schemaVersion` from the new artifact manifest.